### PR TITLE
improve performance on low-end machines, eliminating 'black flashing'

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -282,7 +282,7 @@ impl<'args> Media<'args> {
 
                         // Clear terminal for next frame
                         for _ in 0..h / 2 {
-                            print!("\x1b[1A\x1b[2K");
+                            print!("\x1b[1A");
                         }
                     }
                     self.config.loop_video


### PR DESCRIPTION
Remove carriage return in clear loop. This does not clear each line, but returns to the start anyway, leaving the old frame to be overwritten instead. Instead of the "black flashing" created by clearing the lines, certain terminals will instead experience some minor screen tearing -- much less jarring than the original effect.